### PR TITLE
Add iburst ntp option

### DIFF
--- a/package/yast2-caasp.changes
+++ b/package/yast2-caasp.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 27 11:56:47 UTC 2017 - igonzalezsosa@suse.com
+
+- Add the iburst option to the NTP server configuration
+  (FATE#323249)
+- 1.0.3
+
+-------------------------------------------------------------------
 Fri Apr 21 15:51:51 UTC 2017 - igonzalezsosa@suse.com
 
 - Configure the administration node as a NTP server/client

--- a/package/yast2-caasp.spec
+++ b/package/yast2-caasp.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-caasp
-Version:        1.0.2
+Version:        1.0.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2system_role_handlers/dashboard_role_finish.rb
+++ b/src/lib/y2system_role_handlers/dashboard_role_finish.rb
@@ -70,10 +70,12 @@ module Y2SystemRoleHandlers
       ntp_conf.save
     end
 
+    SERVER_OPTIONS = ["iburst"].freeze
+    # Build a server record
     def server_record(server)
       CFA::NtpConf::Record.record_class("server").new.tap do |record|
         record.value = server
-        record.options = ["iburst"]
+        record.options = SERVER_OPTIONS
       end
     end
 

--- a/src/lib/y2system_role_handlers/dashboard_role_finish.rb
+++ b/src/lib/y2system_role_handlers/dashboard_role_finish.rb
@@ -70,7 +70,9 @@ module Y2SystemRoleHandlers
       ntp_conf.save
     end
 
+    # Options for each defined server
     SERVER_OPTIONS = ["iburst"].freeze
+
     # Build a server record
     def server_record(server)
       CFA::NtpConf::Record.record_class("server").new.tap do |record|

--- a/src/lib/y2system_role_handlers/dashboard_role_finish.rb
+++ b/src/lib/y2system_role_handlers/dashboard_role_finish.rb
@@ -73,6 +73,7 @@ module Y2SystemRoleHandlers
     def server_record(server)
       CFA::NtpConf::Record.record_class("server").new.tap do |record|
         record.value = server
+        record.options = ["iburst"]
       end
     end
 

--- a/test/lib/y2system_role_handlers/dashboard_role_finish_test.rb
+++ b/test/lib/y2system_role_handlers/dashboard_role_finish_test.rb
@@ -43,6 +43,7 @@ describe Y2SystemRoleHandlers::DashboardRoleFinish do
         handler.run
         records = ntp_conf.records.select { |r| r.type == "server" }
         expect(records.map(&:value)).to eq([ntp_server])
+        expect(records.first.options).to eq(["iburst"])
       end
 
       it "writes the NTP configuration" do

--- a/test/lib/y2system_role_handlers/dashboard_role_finish_test.rb
+++ b/test/lib/y2system_role_handlers/dashboard_role_finish_test.rb
@@ -43,7 +43,7 @@ describe Y2SystemRoleHandlers::DashboardRoleFinish do
         handler.run
         records = ntp_conf.records.select { |r| r.type == "server" }
         expect(records.map(&:value)).to eq([ntp_server])
-        expect(records.first.options).to eq(["iburst"])
+        expect(records.map(&:options)).to eq([["iburst"]])
       end
 
       it "writes the NTP configuration" do


### PR DESCRIPTION
Add the iburst option. I didn't introduce this option on the initial version because an (already solved) bug in CFA. Now we can happily add it as we do in openSUSE.