### PR TITLE
Enable counting overall rating in .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,3 +3,14 @@ engines:
   # the /usr/share/YaST2/data/devtools/data/rubocop_yast_style.yml file
   rubocop:
     enabled: false
+
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+
+ratings:
+  paths:
+  - "**.rb"
+  - Rakefile


### PR DESCRIPTION
The https://codeclimate.com/github/yast/yast-caasp result is empty, let's try to fix that.

See https://docs.codeclimate.com/docs/ratings for details.