### PR TITLE
Add dependency on yast-slp

### DIFF
--- a/package/yast2-caasp.spec
+++ b/package/yast2-caasp.spec
@@ -44,6 +44,9 @@ BuildRequires:  yast2-registration >= 3.1.190
 # new keyboard layout cwm widget
 BuildRequires:  yast2-country      >= 3.1.33.1
 Requires:       yast2-country      >= 3.1.33.1
+# SlpServices.find
+Requires:      yast2-slp
+BuildRequires: yast2-slp
 
 BuildRequires:  yast2-devtools     >= 3.1.39
 BuildRequires:  rubygem(rspec)


### PR DESCRIPTION
Moves the yast2-slp from yast2-installation (see https://github.com/yast/yast-installation/pull/558).