### PR TITLE
Remove "Authors" from %description

### DIFF
--- a/package/yast2-caasp.spec
+++ b/package/yast2-caasp.spec
@@ -62,11 +62,6 @@ Url:            https://github.com/yast/yast-caasp
 %description
 Containers as a Service Platform (CaaSP) specific module.
 
-
-Authors:
---------
-    YaST Team <yast-devel@opensuse.org>
-
 %prep
 %setup -n %{name}-%{version}
 


### PR DESCRIPTION
It is not used anymore.

- No version change, this is just to fix this Factory submission: https://build.opensuse.org/request/show/491021