### PR TITLE
Fix test regarding invalid SLP URLs

### DIFF
--- a/test/inst_casp_overview_test.rb
+++ b/test/inst_casp_overview_test.rb
@@ -148,28 +148,7 @@ describe ::Y2Caasp::InstCaspOverview do
       let(:ntp_servers) do
         [
           double("server1", slp_url: "service:ntp://server1.lan:123,65535"),
-          double("error1", slp_url: "service:ntp://*,65535"),
-          double("error2", slp_url: "ntp:,65535")
-        ]
-      end
-
-      it "proposes only the valid ones" do
-        expect(Y2Caasp::Widgets::NtpServer).to receive(:new)
-          .with(["server1.lan"]).and_call_original
-        subject.run
-      end
-
-      it "logs the problem" do
-        expect(subject.log).to receive(:warn).twice.with(/not a valid URI/)
-        subject.run
-      end
-    end
-
-    context "when some SLP URL cannot be parsed" do
-      let(:ntp_servers) do
-        [
-          double("server1", slp_url: "service:ntp://server1.lan:123,65535"),
-          double("error1", slp_url: "service:ntp://*,65535"),
+          double("error1", slp_url: "service:ntp://%,65535"),
           double("error2", slp_url: "ntp:,65535")
         ]
       end


### PR DESCRIPTION
URI("ntp://*") behaves in a different way depending on the Ruby version. For Ruby 2.1, it raises an `URI::InvalidURIError`; for Ruby 2.2, it just works and considers `*` to be the hostname.