### PR TITLE
Fixed yast2-network dependency

### DIFF
--- a/package/yast2-caasp.spec
+++ b/package/yast2-caasp.spec
@@ -33,8 +33,8 @@ BuildRequires:  yast2-installation >= 3.2.38
 Requires:       yast2-ntp-client   >= 4.0.3
 BuildRequires:  yast2-ntp-client   >= 4.0.3
 # parsing dhcp leases (ntp)
-Requires:       yast2-network   >= 4.0.73
-BuildRequires:  yast2-network   >= 4.0.73
+Requires:       yast2-network   >= 4.0.42
+BuildRequires:  yast2-network   >= 4.0.42
 
 BuildRequires:  yast2-devtools     >= 3.1.39
 BuildRequires:  rubygem(rspec)


### PR DESCRIPTION
- By mistake I used the version of yast2-installation instead of yast2-network...
- See https://build.suse.de/package/show/Devel:YaST:CASP:4.0/yast2-network
- There is already yast2-network-4.0.43, but 4.0.42 would be enough