### PR TITLE
Allow Kubic specific options

### DIFF
--- a/package/yast2-caasp.changes
+++ b/package/yast2-caasp.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Nov  9 16:09:30 UTC 2018 - lslezak@suse.cz
+
+- Kubic updates (bsc#1114818)
+  - Propose using the openSUSE pool.ntp.org servers when the DHCP
+    response does not continue any
+  - Updated kubeadm dialog title
+
+-------------------------------------------------------------------
 Thu Oct 25 14:06:41 UTC 2018 - lslezak@suse.cz
 
 - Added role dialogs for SUSE CaaSP and openSUSE Kubic (FATE#325834)

--- a/package/yast2-caasp.changes
+++ b/package/yast2-caasp.changes
@@ -3,7 +3,7 @@ Fri Nov  9 16:09:30 UTC 2018 - lslezak@suse.cz
 
 - Kubic updates (bsc#1114818)
   - Propose using the openSUSE pool.ntp.org servers when the DHCP
-    response does not continue any
+    response does not include any
   - Updated kubeadm dialog title
 
 -------------------------------------------------------------------

--- a/src/clients/inst_kubic_kubeadm_role.rb
+++ b/src/clients/inst_kubic_kubeadm_role.rb
@@ -1,4 +1,3 @@
 
-# so far the Kubic dialog is the same as in CaaSP
-require "y2caasp/clients/admin_role_dialog"
-Y2Caasp::AdminRoleDialog.new.run
+require "y2caasp/clients/kubeadm_role_dialog"
+Y2Caasp::KubeadmRoleDialog.new.run

--- a/src/lib/y2caasp/clients/admin_role_dialog.rb
+++ b/src/lib/y2caasp/clients/admin_role_dialog.rb
@@ -35,7 +35,13 @@ module Y2Caasp
       super
     end
 
+    #
+    # The dialog title
+    #
+    # @return [String] the title
+    #
     def title
+      # TRANSLATORS: dialog title
       _("Admin Node Configuration")
     end
 
@@ -45,8 +51,37 @@ module Y2Caasp
       @content = HSquash(
         MinWidth(50,
           # preselect the servers from the DHCP response
-          Y2Caasp::Widgets::NtpServer.new(dhcp_ntp_servers))
+          Y2Caasp::Widgets::NtpServer.new(ntp_servers))
       )
+    end
+
+  private
+
+    #
+    # Propose the NTP servers
+    #
+    # @return [Array<String>] proposed NTP servers, empty if nothing suitable found
+    #
+    def ntp_servers
+      # TODO: use Yast::NtpClient.ntp_conf if configured
+      # to better handle going back
+      servers = dhcp_ntp_servers
+      servers << ntp_fallback if servers.empty? && ntp_fallback
+
+      servers
+    end
+
+  protected
+
+    #
+    # The fallback servers for NTP configuration, used when there is no
+    # server specified in the DHCP response.
+    #
+    # @return [String,nil] the fallback servers (comma or space separated),
+    #   nil for none
+    #
+    def ntp_fallback
+      nil
     end
   end
 end

--- a/src/lib/y2caasp/clients/admin_role_dialog.rb
+++ b/src/lib/y2caasp/clients/admin_role_dialog.rb
@@ -19,6 +19,7 @@
 # current contact information at www.suse.com.
 # ------------------------------------------------------------------------------
 
+require "yast"
 require "cwm/dialog"
 require "y2caasp/widgets/ntp_server"
 require "y2caasp/dhcp_ntp_servers"
@@ -32,6 +33,9 @@ module Y2Caasp
 
     def initialize
       textdomain "caasp"
+
+      Yast.import "Product"
+      Yast.import "ProductFeatures"
       super
     end
 
@@ -58,7 +62,8 @@ module Y2Caasp
   private
 
     #
-    # Propose the NTP servers
+    # Propose the NTP servers from the DHCP response, fallback to a random
+    # machine from the ntp.org pool if enabled in control.xml.
     #
     # @return [Array<String>] proposed NTP servers, empty if nothing suitable found
     #
@@ -66,21 +71,31 @@ module Y2Caasp
       # TODO: use Yast::NtpClient.ntp_conf if configured
       # to better handle going back
       servers = dhcp_ntp_servers
-      servers << ntp_fallback if servers.empty? && ntp_fallback
+      servers = ntp_fallback if servers.empty?
 
       servers
     end
 
-  protected
-
     #
-    # The fallback server for NTP configuration, used when there is no
-    # server specified in the DHCP response.
+    # The fallback servers for NTP configuration
     #
-    # @return [String,nil] the fallback server, nil for none
+    # @return [Array<String>] the fallback servers, empty if disabled in control.xml
     #
     def ntp_fallback
-      nil
+      # propose the fallback when enabled in control file
+      return [] unless Yast::ProductFeatures.GetBooleanFeature("globals", "default_ntp_setup")
+
+      # copied from timezone/dialogs.rb:
+      base_products = Yast::Product.FindBaseProducts
+      host = if base_products.any? { |p| p["name"] =~ /openSUSE/i }
+        "opensuse"
+      else
+        # TODO: use a SUSE server when available in the future
+        "novell"
+      end
+
+      # propose a random pool server in range 0..3
+      ["#{rand(4)}.#{host}.pool.ntp.org"]
     end
   end
 end

--- a/src/lib/y2caasp/clients/admin_role_dialog.rb
+++ b/src/lib/y2caasp/clients/admin_role_dialog.rb
@@ -74,11 +74,10 @@ module Y2Caasp
   protected
 
     #
-    # The fallback servers for NTP configuration, used when there is no
+    # The fallback server for NTP configuration, used when there is no
     # server specified in the DHCP response.
     #
-    # @return [String,nil] the fallback servers (comma or space separated),
-    #   nil for none
+    # @return [String,nil] the fallback server, nil for none
     #
     def ntp_fallback
       nil

--- a/src/lib/y2caasp/clients/kubeadm_role_dialog.rb
+++ b/src/lib/y2caasp/clients/kubeadm_role_dialog.rb
@@ -26,6 +26,11 @@ module Y2Caasp
 
   protected
 
+    #
+    # Fallback NTP server
+    #
+    # @return [String] The fallback server name
+    #
     def ntp_fallback
       # propose random pool server in range 0..3 if not set via DHCP
       "#{rand(4)}.opensuse.pool.ntp.org"

--- a/src/lib/y2caasp/clients/kubeadm_role_dialog.rb
+++ b/src/lib/y2caasp/clients/kubeadm_role_dialog.rb
@@ -1,0 +1,34 @@
+require "yast"
+
+# so far the Kubic dialog is the same as in CaaSP,
+# just with different title and defaults
+require "y2caasp/clients/admin_role_dialog"
+
+module Y2Caasp
+  # This library provides a simple dialog for setting
+  # the kubeadm role specific settings:
+  #   - the NTP server names
+  class KubeadmRoleDialog < AdminRoleDialog
+    def initialize
+      textdomain "caasp"
+      super
+    end
+
+    #
+    # The dialog title
+    #
+    # @return [String] the title
+    #
+    def title
+      # TRANSLATORS: dialog title
+      _("kubeadm node configuration")
+    end
+
+  protected
+
+    def ntp_fallback
+      # propose random pool server in range 0..3 if not set via DHCP
+      "#{rand(4)}.opensuse.pool.ntp.org"
+    end
+  end
+end

--- a/src/lib/y2caasp/clients/kubeadm_role_dialog.rb
+++ b/src/lib/y2caasp/clients/kubeadm_role_dialog.rb
@@ -23,17 +23,5 @@ module Y2Caasp
       # TRANSLATORS: dialog title
       _("kubeadm node configuration")
     end
-
-  protected
-
-    #
-    # Fallback NTP server
-    #
-    # @return [String] The fallback server name
-    #
-    def ntp_fallback
-      # propose random pool server in range 0..3 if not set via DHCP
-      "#{rand(4)}.opensuse.pool.ntp.org"
-    end
   end
 end

--- a/src/lib/y2caasp/dhcp_ntp_servers.rb
+++ b/src/lib/y2caasp/dhcp_ntp_servers.rb
@@ -39,7 +39,7 @@ module Y2Caasp
       # interfaces e.g. using a bash command or initialize whole networking module.
       Yast::Lan.ReadWithCacheNoGUI
 
-      Yast::LanItems.dhcp_ntp_servers.values.reduce(&:concat) || []
+      Yast::LanItems.dhcp_ntp_servers.values.flatten.uniq
     end
   end
 end

--- a/src/lib/y2caasp/dhcp_ntp_servers.rb
+++ b/src/lib/y2caasp/dhcp_ntp_servers.rb
@@ -20,7 +20,7 @@
 require "yast"
 
 module Y2Caasp
-  # This module provides a functionlity for reading the NTP servers
+  # This module provides a functionality for reading the NTP servers
   # from the DHCP response
   module DhcpNtpServers
     #

--- a/src/lib/y2caasp/dhcp_ntp_servers.rb
+++ b/src/lib/y2caasp/dhcp_ntp_servers.rb
@@ -17,6 +17,8 @@
 # current contact information at www.suse.com.
 # ------------------------------------------------------------------------------
 
+require "yast"
+
 module Y2Caasp
   # This module provides a functionlity for reading the NTP servers
   # from the DHCP response

--- a/test/lib/y2caasp/clients/admin_role_dialog_test.rb
+++ b/test/lib/y2caasp/clients/admin_role_dialog_test.rb
@@ -20,9 +20,28 @@ describe ::Y2Caasp::AdminRoleDialog do
       allow(Yast::CWM).to receive(:show).and_return(:next)
       allow(Yast::Lan).to receive(:ReadWithCacheNoGUI)
       allow(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return({})
+      allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
     end
 
     include_examples "CWM::Dialog"
     include_examples "NTP from DHCP"
+
+    # Note: this is a hypothetical test, in real CaaSP the default NTP setup
+    # is currently disabled in control.xml
+    context "no NTP server set in DHCP and default NTP is enabled in control.xml" do
+      before do
+        allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
+          .with("globals", "default_ntp_setup").and_return(true)
+        allow(Yast::Product).to receive(:FindBaseProducts)
+          .and_return(["name" => "CAASP"])
+      end
+
+      it "proposes to use a random novell pool server" do
+        expect(Y2Caasp::Widgets::NtpServer).to receive(:new) do |s|
+          expect(s.first).to match(/\A[0-3]\.novell\.pool\.ntp\.org\z/)
+        end.and_call_original
+        subject.run
+      end
+    end
   end
 end

--- a/test/lib/y2caasp/clients/admin_role_dialog_test.rb
+++ b/test/lib/y2caasp/clients/admin_role_dialog_test.rb
@@ -37,9 +37,10 @@ describe ::Y2Caasp::AdminRoleDialog do
       end
 
       it "proposes to use a random novell pool server" do
-        expect(Y2Caasp::Widgets::NtpServer).to receive(:new) do |s|
-          expect(s.first).to match(/\A[0-3]\.novell\.pool\.ntp\.org\z/)
-        end.and_call_original
+        expect(Y2Caasp::Widgets::NtpServer).to receive(:new).and_wrap_original do |original, arg|
+          expect(arg.first).to match(/\A[0-3]\.novell\.pool\.ntp\.org\z/)
+          original.call(arg)
+        end
         subject.run
       end
     end

--- a/test/lib/y2caasp/clients/kubeadm_role_dialog_test.rb
+++ b/test/lib/y2caasp/clients/kubeadm_role_dialog_test.rb
@@ -20,12 +20,20 @@ describe Y2Caasp::KubeadmRoleDialog do
       allow(Yast::CWM).to receive(:show).and_return(:next)
       allow(Yast::Lan).to receive(:ReadWithCacheNoGUI)
       allow(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return({})
+      allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
     end
 
     include_examples "CWM::Dialog"
     include_examples "NTP from DHCP"
 
-    context "when no NTP server is detected via DHCP" do
+    context "no NTP server set in DHCP and default NTP is enabled in control.xml" do
+      before do
+        allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
+          .with("globals", "default_ntp_setup").and_return(true)
+        allow(Yast::Product).to receive(:FindBaseProducts)
+          .and_return(["name" => "openSUSE-Tumbleweed-Kubic"])
+      end
+
       it "proposes to use a random openSUSE pool server" do
         expect(Y2Caasp::Widgets::NtpServer).to receive(:new) do |s|
           expect(s.first).to match(/\A[0-3]\.opensuse\.pool\.ntp\.org\z/)
@@ -33,6 +41,5 @@ describe Y2Caasp::KubeadmRoleDialog do
         subject.run
       end
     end
-
   end
 end

--- a/test/lib/y2caasp/clients/kubeadm_role_dialog_test.rb
+++ b/test/lib/y2caasp/clients/kubeadm_role_dialog_test.rb
@@ -1,0 +1,38 @@
+#! /usr/bin/env rspec
+
+require_relative "../../../test_helper.rb"
+require_relative "role_dialog_examples"
+require "cwm/rspec"
+
+require "y2caasp/clients/kubeadm_role_dialog.rb"
+
+Yast.import "CWM"
+Yast.import "Lan"
+Yast.import "Wizard"
+
+describe Y2Caasp::KubeadmRoleDialog do
+  describe "#run" do
+    let(:ntp_servers) { [] }
+
+    before do
+      allow(Yast::Wizard).to receive(:CreateDialog)
+      allow(Yast::Wizard).to receive(:CloseDialog)
+      allow(Yast::CWM).to receive(:show).and_return(:next)
+      allow(Yast::Lan).to receive(:ReadWithCacheNoGUI)
+      allow(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return({})
+    end
+
+    include_examples "CWM::Dialog"
+    include_examples "NTP from DHCP"
+
+    context "when no NTP server is detected via DHCP" do
+      it "proposes to use a random openSUSE pool server" do
+        expect(Y2Caasp::Widgets::NtpServer).to receive(:new) do |s|
+          expect(s.first).to match(/\A[0-3]\.opensuse\.pool\.ntp\.org\z/)
+        end.and_call_original
+        subject.run
+      end
+    end
+
+  end
+end

--- a/test/lib/y2caasp/clients/kubeadm_role_dialog_test.rb
+++ b/test/lib/y2caasp/clients/kubeadm_role_dialog_test.rb
@@ -35,9 +35,10 @@ describe Y2Caasp::KubeadmRoleDialog do
       end
 
       it "proposes to use a random openSUSE pool server" do
-        expect(Y2Caasp::Widgets::NtpServer).to receive(:new) do |s|
-          expect(s.first).to match(/\A[0-3]\.opensuse\.pool\.ntp\.org\z/)
-        end.and_call_original
+        expect(Y2Caasp::Widgets::NtpServer).to receive(:new).and_wrap_original do |original, arg|
+          expect(arg.first).to match(/\A[0-3]\.opensuse\.pool\.ntp\.org\z/)
+          original.call(arg)
+        end
         subject.run
       end
     end


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1114818
- For Kubic we need to propose the openSUSE ntp.org pool servers if not configured via DHCP (but not for CaaSP!!).
- Also Richard suggested using a different dialog title.
- No `VERSION` change as this is actually needed only in `master`. But to make the Kubic backports to CaaSP-4.0 easier (to avoid conflicts) I'd like to update the code also in the SLE15 branch.