### PR TITLE
Allow users to set the container registry to use when installing.

### DIFF
--- a/src/lib/y2caasp/cfa/registry_conf.rb
+++ b/src/lib/y2caasp/cfa/registry_conf.rb
@@ -1,0 +1,38 @@
+require "cfa/base_model"
+require "cfa/augeas_parser"
+require "cfa/matcher"
+
+module Y2Caasp
+  module CFA
+    # Represents a Salt Minion master configuration file.
+    class RegistryConf < ::CFA::BaseModel
+      attributes(host: "registry.suse.com")
+      attributes(namespace: "sles12")
+
+      # Configuration parser
+      #
+      # FIXME: At this time, we're using Augeas' cobblersettings lense because,
+      # although the file is in yaml format, it doesn't have a YAML header
+      # which is required by the yaml lense.
+      PARSER = ::CFA::AugeasParser.new("cobblersettings.lns")
+      # Path to configuration file
+      # FIXME: These changes need to be mirrored to the workers later.
+      PATH = "/usr/share/caasp-container-manifests/config/registry/registry-config.yaml".freeze
+
+      # Constructor
+      #
+      # @param file_handler [.read, .write, nil] an object able to read/write a string.
+      def initialize(file_handler: nil)
+        super(PARSER, PATH, file_handler: file_handler)
+      end
+
+      def host=(host_name)
+        data["host"] = host_name
+      end
+
+      def namespace=(registry_namespace)
+        data["namespace"] = registry_namespace
+      end
+    end
+  end
+end

--- a/src/lib/y2caasp/clients/admin_role_dialog.rb
+++ b/src/lib/y2caasp/clients/admin_role_dialog.rb
@@ -22,6 +22,8 @@
 require "yast"
 require "cwm/dialog"
 require "y2caasp/widgets/ntp_server"
+require "y2caasp/widgets/container_registry_host"
+require "y2caasp/widgets/container_registry_namespace"
 require "y2caasp/dhcp_ntp_servers"
 
 module Y2Caasp
@@ -53,9 +55,17 @@ module Y2Caasp
       return @content if @content
 
       @content = HSquash(
-        MinWidth(50,
+        MinWidth(
+          50,
           # preselect the servers from the DHCP response
-          Y2Caasp::Widgets::NtpServer.new(ntp_servers))
+          VBox(
+            Y2Caasp::Widgets::NtpServer.new(ntp_servers),
+            VSpacing(2),
+            Y2Caasp::Widgets::ContainerRegistryHost.new("registry.suse.com"),
+            VSpacing(1),
+            Y2Caasp::Widgets::ContainerRegistryNamespace.new("sles12")
+          )
+        )
       )
     end
 

--- a/src/lib/y2caasp/widgets/container_registry_host.rb
+++ b/src/lib/y2caasp/widgets/container_registry_host.rb
@@ -1,0 +1,91 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm/widget"
+require "installation/system_role"
+
+module Y2Caasp
+  module Widgets
+    # This widget is responsible to validate and store the registry host.
+    # The host must be a valid IP of FQDN.
+    class ContainerRegistryHost < CWM::InputField
+      attr_reader :default_host
+
+      def initialize(default_host = "")
+        @default_host = default_host
+        textdomain "caasp"
+      end
+
+      def label
+        _("Container registry host")
+      end
+
+      def help
+        # TRANSLATORS: a help text for the controller node input field
+        _("<h3>The Container Registry Host</h3>") +
+          # TRANSLATORS: a help text for the controller node input field
+          _("<p>Enter the host, that runs the registry." \
+            "It must have all container-images required to run CaaS Platform available.</p>")
+      end
+
+      # It stores the value of the input field if validates
+      #
+      # @see #validate
+      def store
+        # this is a role widget so a role must be selected before saving
+        raise("No role selected") unless role
+        role["registry_host"] = value
+      end
+
+      # The input field is initialized with previous stored value
+      def init
+        self.value = if role && role["registry_host"]
+          role["registry_host"]
+        else
+          @default_host
+        end
+      end
+
+      # It returns true if the value is a valid IP or a valid FQDN, if not it
+      # displays a popup error.
+      #
+      # @return [Boolean] true if valid IP or FQDN
+      def validate
+        return true if Yast::IP.Check(value) || Yast::Hostname.CheckFQ(value)
+
+        Yast::Popup.Error(
+          # TRANSLATORS: error message for invalid administration node location
+          _("Not a valid location for the registry, please enter a valid IP or Hostname")
+        )
+
+        false
+      end
+
+    private
+
+      # All other widgets have this
+      def role
+        ::Installation::SystemRole.current_role
+      end
+    end
+  end
+end

--- a/src/lib/y2caasp/widgets/container_registry_namespace.rb
+++ b/src/lib/y2caasp/widgets/container_registry_namespace.rb
@@ -1,0 +1,77 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm/widget"
+require "installation/system_role"
+
+module Y2Caasp
+  module Widgets
+    # This widget is responsible to store the registry namespace.
+    class ContainerRegistryNamespace < CWM::InputField
+      attr_reader :default_namespace
+
+      def initialize(default_namespace = "")
+        @default_namespace = default_namespace
+        textdomain "caasp"
+      end
+
+      def label
+        _("Container registry namespace")
+      end
+
+      def help
+        # TRANSLATORS: a help text for the controller node input field
+        _("<h3>The Container Registry Namespace</h3>") +
+          # TRANSLATORS: a help text for the controller node input field
+          _("<p>Enter the namespace, under which the " \
+            "container images required to run caasp can be found.</p>" \
+            "<p>E.g. if all images are found on registry.suse.com/caasp/4.0/" \
+            "the namespace would be 'caasp/4.0'.")
+      end
+
+      # It stores the value of the input field if validates
+      #
+      # @see #validate
+      def store
+        # this is a role widget so a role must be selected before saving
+        raise("No role selected") unless role
+        role["registry_namespace"] = value
+      end
+
+      # The input field is initialized with previous stored value
+      def init
+        self.value = if role && role["registry_namespace"]
+          role["registry_namespace"]
+        else
+          @default_namespace
+        end
+      end
+
+    private
+
+      # All other widgets have this
+      def role
+        ::Installation::SystemRole.current_role
+      end
+    end
+  end
+end

--- a/src/lib/y2system_role_handlers/dashboard_role_finish.rb
+++ b/src/lib/y2system_role_handlers/dashboard_role_finish.rb
@@ -24,6 +24,7 @@ require "yast2/execute"
 require "installation/system_role"
 require "installation/services"
 require "cfa/chrony_conf"
+require "y2caasp/cfa/registry_conf"
 
 module Y2SystemRoleHandlers
   # Implement finish handler for the "dashboard" role
@@ -36,6 +37,7 @@ module Y2SystemRoleHandlers
     def run
       run_activation_script
       setup_ntp
+      update_registry_conf
     end
 
   protected
@@ -68,6 +70,17 @@ module Y2SystemRoleHandlers
         chrony_conf.add_pool(server)
       end
       chrony_conf.save
+    end
+
+    def update_registry_conf
+      log.info "Updating registry configuration: " \
+               "host #{role["registry_host"]} namespace #{role["registry_namespace"]}"
+      return unless role["registry_host"] && role["registry_namespace"]
+      registry_conf = ::Y2Caasp::CFA::RegistryConf.new
+      registry_conf.load
+      registry_conf.host = role["registry_host"]
+      registry_conf.namespace = role["registry_namespace"]
+      registry_conf.save
     end
 
     # Add the ntpd service to the list of services to enable

--- a/test/fixtures/registry-conf.yaml
+++ b/test/fixtures/registry-conf.yaml
@@ -1,0 +1,10 @@
+# This file defines whether to use container-feeder packaged images or a
+# registry.
+#
+# If use_registry is set to false, the system should use container-feeder images
+# and ignore the host and namespace.
+#
+# namespace: denotes the root namespace under which all images can be found.
+use_registry: false
+host: registry.suse.de
+namespace: devel/casp/3.0/controllernode/images_container_base/sles12

--- a/test/lib/widgets/container_registry_host_test.rb
+++ b/test/lib/widgets/container_registry_host_test.rb
@@ -1,0 +1,91 @@
+#!/usr/bin/env rspec
+
+require_relative "../../test_helper"
+require "cwm/rspec"
+require "y2caasp/widgets/container_registry_host"
+
+describe Y2Caasp::Widgets::ContainerRegistryHost do
+  subject(:widget) { Y2Caasp::Widgets::ContainerRegistryHost.new }
+  let(:dashboard_role) { ::Installation::SystemRole.new(id: "dashboard_role", order: "100") }
+
+  before do
+    allow(::Installation::SystemRole).to receive(:current_role).and_return(dashboard_role)
+  end
+
+  include_examples "CWM::AbstractWidget"
+
+  describe "#init" do
+    subject(:widget) { Y2Caasp::Widgets::ContainerRegistryHost.new("default.registry.com") }
+
+    it "reads initial value from dashboard role" do
+      allow(dashboard_role).to receive(:[]).with("registry_host")
+        .and_return("registry.suse.com")
+      expect(widget).to receive(:value=).with("registry.suse.com")
+      widget.init
+    end
+
+    context "when dashboard role does not define any server" do
+      it "uses the default servers" do
+        expect(widget).to receive(:value=).with("default.registry.com")
+        widget.init
+      end
+    end
+  end
+
+  describe "#store" do
+    let(:value) { "my.registry.com" }
+
+    before do
+      allow(widget).to receive(:value).and_return(value)
+    end
+
+    it "sets the role registry_host property" do
+      widget.store
+      expect(dashboard_role["registry_host"]).to eq(value)
+    end
+  end
+
+  describe "#validate" do
+    before do
+      allow(widget).to receive(:value).and_return(value)
+    end
+
+    context "when valid IP addresses are provided" do
+      let(:value) { "192.168.122.1" }
+
+      it "returns true" do
+        expect(widget.validate).to eq(true)
+      end
+    end
+
+    context "when valid hostnames are provided" do
+      let(:value) { "my.registry.de" }
+
+      it "returns true" do
+        expect(widget.validate).to eq(true)
+      end
+    end
+
+    context "when non valid addresses/hostnames are provided" do
+      let(:value) { "my.registry.*" }
+
+      it "returns false" do
+        allow(Yast::Popup).to receive(:Error)
+        expect(widget.validate).to eq(false)
+      end
+
+      it "reports the problem to the user" do
+        expect(Yast::Popup).to receive(:Error)
+        widget.validate
+      end
+    end
+
+    context "when no value is provided" do
+      let(:value) { "" }
+
+      it "returns false" do
+        expect(widget.validate).to eq(false)
+      end
+    end
+  end
+end

--- a/test/lib/widgets/container_registry_namespace_test.rb
+++ b/test/lib/widgets/container_registry_namespace_test.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env rspec
+
+require_relative "../../test_helper"
+require "cwm/rspec"
+require "y2caasp/widgets/container_registry_namespace"
+
+describe Y2Caasp::Widgets::ContainerRegistryNamespace do
+  subject(:widget) { Y2Caasp::Widgets::ContainerRegistryNamespace.new }
+  let(:dashboard_role) { ::Installation::SystemRole.new(id: "dashboard_role", order: "100") }
+
+  before do
+    allow(::Installation::SystemRole).to receive(:current_role).and_return(dashboard_role)
+  end
+
+  include_examples "CWM::AbstractWidget"
+
+  describe "#init" do
+    subject(:widget) { Y2Caasp::Widgets::ContainerRegistryNamespace.new("a/namespace") }
+
+    it "reads initial value from dashboard role" do
+      allow(dashboard_role).to receive(:[]).with("registry_namespace")
+        .and_return("other/namespace")
+      expect(widget).to receive(:value=).with("other/namespace")
+      widget.init
+    end
+
+    context "when dashboard role does not define any namespace" do
+      it "uses the default namespace" do
+        expect(widget).to receive(:value=).with("a/namespace")
+        widget.init
+      end
+    end
+  end
+
+  describe "#store" do
+    let(:value) { "my/namespace" }
+
+    before do
+      allow(widget).to receive(:value).and_return(value)
+    end
+
+    it "sets the role registry_namespace property" do
+      widget.store
+      expect(dashboard_role["registry_namespace"]).to eq(value)
+    end
+  end
+end

--- a/test/lib/y2system_role_handlers/dashboard_role_finish_test.rb
+++ b/test/lib/y2system_role_handlers/dashboard_role_finish_test.rb
@@ -8,15 +8,21 @@ describe Y2SystemRoleHandlers::DashboardRoleFinish do
 
   let(:ntp_server) { "ntp.suse.de" }
   let(:ntp_servers) { [ntp_server] }
+  let(:registry_host) { "registry.suse.de" }
+  let(:registry_namespace) { "sles12/test" }
 
   before do
     stub_const("CFA::ChronyConf::PATH", FIXTURES_PATH.join("chrony.conf").to_s)
     allow(CFA::ChronyConf).to receive(:new).and_return(ntp_conf)
+    stub_const("::Y2Caasp::CFA::RegistryConf::PATH", FIXTURES_PATH.join("registry-conf.yaml").to_s)
+    allow(::Y2Caasp::CFA::RegistryConf).to receive(:new).and_return(registry_conf)
   end
 
   let(:role) do
     ::Installation::SystemRole.new(id: "dashboard_role", order: "100").tap do |role|
       role["ntp_servers"] = ntp_servers
+      role["registry_host"] = registry_host
+      role["registry_namespace"] = registry_namespace
     end
   end
 
@@ -28,9 +34,11 @@ describe Y2SystemRoleHandlers::DashboardRoleFinish do
 
   describe "#run" do
     let(:ntp_conf) { CFA::ChronyConf.new }
+    let(:registry_conf) { ::Y2Caasp::CFA::RegistryConf.new }
 
     before do
       allow(ntp_conf).to receive(:save)
+      allow(registry_conf).to receive(:save)
     end
 
     it "runs the activation script" do
@@ -62,6 +70,25 @@ describe Y2SystemRoleHandlers::DashboardRoleFinish do
 
       it "does not modify NTP configuration" do
         expect(CFA::ChronyConf).to_not receive(:new)
+        handler.run
+      end
+    end
+
+    context "when a registry host and namespace is specified" do
+      it "saves the host and namespace to the configuration" do
+        expect(registry_conf).to receive(:load)
+        expect(registry_conf).to receive(:save)
+        handler.run
+      end
+    end
+
+    context "when neither namespace nor host is specified" do
+      let(:registry_host) { nil }
+      let(:registry_namespace) { nil }
+
+      it "it leaves the configuration untouched" do
+        expect(registry_conf).not_to receive(:load)
+        expect(registry_conf).not_to receive(:save)
         handler.run
       end
     end


### PR DESCRIPTION
This feature is only applicable for SLE15 based CaaSP installations, as those
will no longer use container-feeder, but download the docker images from a
registry instead.

By default this registry will be the official suse registry (registry.suse.com),
but the customer always has the possibility to mirror it, in which case he can
then set the differing values during installation.