### PR TITLE
[SLE-7188] Default to SUSE NTP servers

### DIFF
--- a/package/yast2-caasp.changes
+++ b/package/yast2-caasp.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 19 12:57:29 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Rely on the new Y2Network::NtpServer class (jsc#SLE-7188).
+- 4.2.3
+
+-------------------------------------------------------------------
 Mon Aug 26 09:31:45 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-caasp.spec
+++ b/package/yast2-caasp.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-caasp
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -32,9 +32,9 @@ BuildRequires:  yast2-installation >= 3.2.38
 # chrony support
 Requires:       yast2-ntp-client   >= 4.0.3
 BuildRequires:  yast2-ntp-client   >= 4.0.3
-# parsing dhcp leases (ntp)
-Requires:       yast2-network   >= 4.1.11
-BuildRequires:  yast2-network   >= 4.1.11
+# Y2Network::NtpServer
+Requires:       yast2-network      >= 4.2.55
+BuildRequires:  yast2-network      >= 4.2.55
 
 BuildRequires:  yast2-devtools     >= 3.1.39
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)

--- a/src/lib/y2caasp/clients/admin_role_dialog.rb
+++ b/src/lib/y2caasp/clients/admin_role_dialog.rb
@@ -23,6 +23,7 @@ require "yast"
 require "cwm/dialog"
 require "y2caasp/widgets/ntp_server"
 require "y2caasp/dhcp_ntp_servers"
+require "y2network/ntp_server"
 
 module Y2Caasp
   # This library provides a simple dialog for setting
@@ -57,45 +58,6 @@ module Y2Caasp
           # preselect the servers from the DHCP response
           Y2Caasp::Widgets::NtpServer.new(ntp_servers))
       )
-    end
-
-  private
-
-    #
-    # Propose the NTP servers from the DHCP response, fallback to a random
-    # machine from the ntp.org pool if enabled in control.xml.
-    #
-    # @return [Array<String>] proposed NTP servers, empty if nothing suitable found
-    #
-    def ntp_servers
-      # TODO: use Yast::NtpClient.ntp_conf if configured
-      # to better handle going back
-      servers = dhcp_ntp_servers
-      servers = ntp_fallback if servers.empty?
-
-      servers
-    end
-
-    #
-    # The fallback servers for NTP configuration
-    #
-    # @return [Array<String>] the fallback servers, empty if disabled in control.xml
-    #
-    def ntp_fallback
-      # propose the fallback when enabled in control file
-      return [] unless Yast::ProductFeatures.GetBooleanFeature("globals", "default_ntp_setup")
-
-      # copied from timezone/dialogs.rb:
-      base_products = Yast::Product.FindBaseProducts
-      host = if base_products.any? { |p| p["name"] =~ /openSUSE/i }
-        "opensuse"
-      else
-        # TODO: use a SUSE server when available in the future
-        "novell"
-      end
-
-      # propose a random pool server in range 0..3
-      ["#{rand(4)}.#{host}.pool.ntp.org"]
     end
   end
 end

--- a/src/lib/y2caasp/clients/kubic_minion_role_dialog.rb
+++ b/src/lib/y2caasp/clients/kubic_minion_role_dialog.rb
@@ -23,6 +23,7 @@ require "cwm/dialog"
 require "y2caasp/widgets/kubic_admin_node"
 require "y2caasp/widgets/ntp_server"
 require "y2caasp/dhcp_ntp_servers"
+require "y2network/ntp_server"
 
 module Y2Caasp
   # This library provides a simple dialog for setting
@@ -57,45 +58,6 @@ module Y2Caasp
             Y2Caasp::Widgets::NtpServer.new(ntp_servers)
           ))
       )
-    end
-
-  private
-
-    #
-    # Propose the NTP servers from the DHCP response, fallback to a random
-    # machine from the ntp.org pool if enabled in control.xml.
-    #
-    # @return [Array<String>] proposed NTP servers, empty if nothing suitable found
-    #
-    def ntp_servers
-      # TODO: use Yast::NtpClient.ntp_conf if configured
-      # to better handle going back
-      servers = dhcp_ntp_servers
-      servers = ntp_fallback if servers.empty?
-
-      servers
-    end
-
-    #
-    # The fallback servers for NTP configuration
-    #
-    # @return [Array<String>] the fallback servers, empty if disabled in control.xml
-    #
-    def ntp_fallback
-      # propose the fallback when enabled in control file
-      return [] unless Yast::ProductFeatures.GetBooleanFeature("globals", "default_ntp_setup")
-
-      # copied from timezone/dialogs.rb:
-      base_products = Yast::Product.FindBaseProducts
-      host = if base_products.any? { |p| p["name"] =~ /openSUSE/i }
-        "opensuse"
-      else
-        # TODO: use a SUSE server when available in the future
-        "novell"
-      end
-
-      # propose a random pool server in range 0..3
-      ["#{rand(4)}.#{host}.pool.ntp.org"]
     end
   end
 end

--- a/test/lib/y2caasp/clients/kubic_minion_role_dialog_test.rb
+++ b/test/lib/y2caasp/clients/kubic_minion_role_dialog_test.rb
@@ -1,0 +1,72 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper.rb"
+require_relative "role_dialog_examples"
+require "cwm/rspec"
+
+require "y2caasp/clients/kubic_minion_role_dialog"
+
+Yast.import "CWM"
+Yast.import "Lan"
+Yast.import "Wizard"
+
+describe ::Y2Caasp::KubicMinionRoleDialog do
+  describe "#run" do
+    let(:ntp_servers) { [] }
+
+    before do
+      allow(Yast::Wizard).to receive(:CreateDialog)
+      allow(Yast::Wizard).to receive(:CloseDialog)
+      allow(Yast::CWM).to receive(:show).and_return(:next)
+      allow(Yast::Lan).to receive(:ReadWithCacheNoGUI)
+      allow(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return({})
+      allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
+    end
+
+    include_examples "CWM::Dialog"
+    include_examples "NTP from DHCP"
+
+    # Note: this is a hypothetical test, in real CaaSP the default NTP setup
+    # is currently disabled in control.xml
+    context "no NTP server set in DHCP and default NTP is enabled in control.xml" do
+      let(:default_servers) do
+        [
+          Y2Network::NtpServer.new("0.suse.pool.ntp.org"),
+          Y2Network::NtpServer.new("1.suse.pool.ntp.org")
+        ]
+      end
+
+      before do
+        allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
+          .with("globals", "default_ntp_setup").and_return(true)
+        allow(Y2Network::NtpServer).to receive(:default_servers).and_return(default_servers)
+      end
+
+      it "proposes to use a random server from the default pool" do
+        expect(Y2Caasp::Widgets::NtpServer).to receive(:new).and_wrap_original do |original, arg|
+          expect(arg.size).to eq(1)
+          expect(arg.first).to match(/suse.pool.ntp.org/)
+          original.call(arg)
+        end
+        subject.run
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use the new `Y2Network::NtpServer` when proposing the default values for NTP servers.

Related PR: https://github.com/yast/yast-network/pull/1039