### PR TITLE
Drop Yast::LanItems dependency

### DIFF
--- a/package/yast2-caasp.changes
+++ b/package/yast2-caasp.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr 27 10:30:25 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Drop Yast::LanItems dependency (bsc#1185338)
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0

--- a/package/yast2-caasp.spec
+++ b/package/yast2-caasp.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-caasp
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-caasp.spec
+++ b/package/yast2-caasp.spec
@@ -32,9 +32,9 @@ BuildRequires:  yast2-installation >= 3.2.38
 # chrony support
 Requires:       yast2-ntp-client   >= 4.0.3
 BuildRequires:  yast2-ntp-client   >= 4.0.3
-# Y2Network::NtpServer
-Requires:       yast2-network      >= 4.2.55
-BuildRequires:  yast2-network      >= 4.2.55
+# Drop Yast::LanItems
+Requires:       yast2-network      >= 4.4.7
+BuildRequires:  yast2-network      >= 4.4.7
 
 BuildRequires:  yast2-devtools     >= 3.1.39
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)

--- a/src/lib/y2caasp/dhcp_ntp_servers.rb
+++ b/src/lib/y2caasp/dhcp_ntp_servers.rb
@@ -29,16 +29,8 @@ module Y2Caasp
     #
     def dhcp_ntp_servers
       Yast.import "Lan"
-      Yast.import "LanItems"
 
-      # When proposing NTP servers we need to know
-      # 1) list of (dhcp) interfaces
-      # 2) network service in use
-      # We can either use networking submodule for network service handling and get list of
-      # interfaces e.g. using a bash command or initialize whole networking module.
-      Yast::Lan.ReadWithCacheNoGUI
-
-      Yast::LanItems.dhcp_ntp_servers.values.flatten.uniq
+      Yast::Lan.dhcp_ntp_servers
     end
 
     #

--- a/test/lib/y2caasp/clients/admin_role_dialog_test.rb
+++ b/test/lib/y2caasp/clients/admin_role_dialog_test.rb
@@ -18,8 +18,7 @@ describe ::Y2Caasp::AdminRoleDialog do
       allow(Yast::Wizard).to receive(:CreateDialog)
       allow(Yast::Wizard).to receive(:CloseDialog)
       allow(Yast::CWM).to receive(:show).and_return(:next)
-      allow(Yast::Lan).to receive(:ReadWithCacheNoGUI)
-      allow(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return({})
+      allow(Yast::Lan).to receive(:dhcp_ntp_servers).and_return([])
       allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
     end
 

--- a/test/lib/y2caasp/clients/kubeadm_role_dialog_test.rb
+++ b/test/lib/y2caasp/clients/kubeadm_role_dialog_test.rb
@@ -18,8 +18,7 @@ describe Y2Caasp::KubeadmRoleDialog do
       allow(Yast::Wizard).to receive(:CreateDialog)
       allow(Yast::Wizard).to receive(:CloseDialog)
       allow(Yast::CWM).to receive(:show).and_return(:next)
-      allow(Yast::Lan).to receive(:ReadWithCacheNoGUI)
-      allow(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return({})
+      allow(Yast::Lan).to receive(:dhcp_ntp_servers).and_return([])
       allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
     end
 

--- a/test/lib/y2caasp/clients/kubic_minion_role_dialog_test.rb
+++ b/test/lib/y2caasp/clients/kubic_minion_role_dialog_test.rb
@@ -35,8 +35,7 @@ describe ::Y2Caasp::KubicMinionRoleDialog do
       allow(Yast::Wizard).to receive(:CreateDialog)
       allow(Yast::Wizard).to receive(:CloseDialog)
       allow(Yast::CWM).to receive(:show).and_return(:next)
-      allow(Yast::Lan).to receive(:ReadWithCacheNoGUI)
-      allow(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return({})
+      allow(Yast::Lan).to receive(:dhcp_ntp_servers).and_return([])
       allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
     end
 

--- a/test/lib/y2caasp/clients/role_dialog_examples.rb
+++ b/test/lib/y2caasp/clients/role_dialog_examples.rb
@@ -4,7 +4,7 @@ shared_examples "NTP from DHCP" do
     let(:ntp_servers) { ["ntp.example.com"] }
 
     it "proposes to use it by default" do
-      expect(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return("eth0" => ntp_servers)
+      expect(Yast::Lan).to receive(:dhcp_ntp_servers).and_return(ntp_servers)
       expect(Y2Caasp::Widgets::NtpServer).to receive(:new)
         .with(ntp_servers).and_call_original
       subject.run

--- a/test/lib/y2caasp/clients/worker_role_dialog_test.rb
+++ b/test/lib/y2caasp/clients/worker_role_dialog_test.rb
@@ -16,8 +16,7 @@ describe ::Y2Caasp::WorkerRoleDialog do
       allow(Yast::Wizard).to receive(:CreateDialog)
       allow(Yast::Wizard).to receive(:CloseDialog)
       allow(Yast::CWM).to receive(:show).and_return(:next)
-      allow(Yast::Lan).to receive(:ReadWithCacheNoGUI)
-      allow(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return({})
+      allow(Yast::Lan).to receive(:dhcp_ntp_servers).and_return([])
     end
 
     include_examples "CWM::Dialog"


### PR DESCRIPTION
## Problem

We have been preparing the drop of **Yast::LanItems** adapting the some code in network which is still used by this module so we need to adapt it to.

- see https://github.com/yast/yast-network/pull/1216
- https://bugzilla.suse.com/show_bug.cgi?id=1185338

## Solution

- Drop Yast::LanItems dependency completely.

It depends on https://github.com/yast/yast-network/pull/1217